### PR TITLE
Data.csv update fix - discard last candle before update

### DIFF
--- a/src/binance_futures_backtest.py
+++ b/src/binance_futures_backtest.py
@@ -293,6 +293,7 @@ class BinanceFuturesBackTest(BinanceFuturesStub):
             self.df_ohlcv.set_index(self.df_ohlcv.columns[0], inplace=True)
 
             if(self.update_data):
+                self.df_ohlcv = self.df_ohlcv[:-1] # exclude last candle
                 data = self.download_data( bin_size, dateutil.parser.isoparse(self.df_ohlcv.iloc[-1].name), end_time)
                 self.df_ohlcv = pd.concat([self.df_ohlcv, data])
                 self.save_csv(self.df_ohlcv, file) 


### PR DESCRIPTION
Discard last candle before updating data.csv as it could be incomplete.