### PR TITLE
Adding Session Persistence using JSON

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
     parser.add_argument("--exchange", default="binance",   required=True)
     parser.add_argument("--pair", default="BTCUSDT",   required=False)
     parser.add_argument("--strategy", default="doten", required=True)
+    parser.add_argument("--session", default=None, required=False)
     args = parser.parse_args()
     conf["args"] = args
 
@@ -28,6 +29,8 @@ if __name__ == "__main__":
 
     if not args.test:
         # register stopping
-        signal.signal(signal.SIGINT, lambda x, y: bot.stop())
+        def term(signum, frame):
+            bot.stop()
+        signal.signal(signal.SIGINT, term)
         while True:
             time.sleep(1)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -51,6 +51,37 @@ allowed_range_minute_granularity = {
     "1d": ["1m", "1440T", 1440, 1440], "3d": ["1m", "4320T", 4320, 4320]
     # not support yet '1w', '2w', '1M'
 }
+# https://stackoverflow.com/questions/3041986/apt-command-line-interface-like-yes-no-input
+def query_yes_no(question, default="yes"):
+    """Ask a yes/no question via raw_input() and return their answer.
+
+    "question" is a string that is presented to the user.
+    "default" is the presumed answer if the user just hits <Enter>.
+            It must be "yes" (the default), "no" or None (meaning
+            an answer is required of the user).
+
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
+
+    while True:
+        logger.info(question + prompt)
+        choice = input().lower()
+        if default is not None and choice == "":
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            logger.info("Please respond with 'yes' or 'no' " "(or 'y' or 'n').\n")
+
 # https://stackoverflow.com/questions/8299386/modifying-a-symlink-in-python/55742015#55742015
 def symlink(target, link_name, overwrite=False):
     

--- a/src/bot.py
+++ b/src/bot.py
@@ -60,6 +60,9 @@ class Bot:
     def __del__(self):
         self.stop()
 
+    def get_session(self):
+        return self.session
+
     def options(self):
         """
         Function to get values for parameter optimization

--- a/src/bot.py
+++ b/src/bot.py
@@ -63,6 +63,9 @@ class Bot:
     def get_session(self):
         return self.session
 
+    def set_session(self, session):
+        self.session.load(session)
+
     def options(self):
         """
         Function to get values for parameter optimization

--- a/src/exchange/binance_futures/binance_futures.py
+++ b/src/exchange/binance_futures/binance_futures.py
@@ -945,8 +945,10 @@ class BinanceFutures:
 
             #logger.info(f"{self.timeframe_info[t]['last_action_time']} : {self.timeframe_data[t].iloc[-1].name} : {re_sample_data.iloc[-1].name}")  
 
-            if self.timeframe_info[t]["last_action_time"] is not None and \
-                self.timeframe_info[t]["last_action_time"] == re_sample_data.iloc[-1].name:
+            if self.timeframe_info[t]["last_action_time"] is None:
+                self.timeframe_info[t]["last_action_time"] = re_sample_data.iloc[-1].name
+                
+            if self.timeframe_info[t]["last_action_time"] == re_sample_data.iloc[-1].name:
                 continue
 
             # The last candle in the buffer needs to be preserved 

--- a/src/factory.py
+++ b/src/factory.py
@@ -2,6 +2,8 @@
 
 import importlib, os
 from src import symlink
+import json #pickle #jsonpickle #json
+from src import logger, query_yes_no
 
 class BotFactory():
 
@@ -27,6 +29,27 @@ class BotFactory():
             STRATEGY_FILENAME = os.path.join(os.getcwd(), f"src/strategies/{args.strategy}.py")
             symlink(STRATEGY_FILENAME, 'html/data/strategy.py', overwrite=True)
             
+            if args.session != None:
+                try:
+                    bot.session_file_name = args.session
+                    bot.session_file = open(args.session,"r+")
+                except Exception as e:
+                    logger.info("Session file not found - Creating!")
+                    bot.session_file = open(args.session,"w")
+                
+                try:
+                    # vars = pickle.load(bot.session_file)
+                    vars = json.load(bot.session_file)
+                    # vars = jsonpickle.decode(bot.session_file.read())
+
+                    use_stored_session = query_yes_no("Session Found. Do you want to use it?", "no")
+                    if use_stored_session:
+                        bot.session.load(vars)
+                except Exception as _:
+                    logger.info("Session file is empty!")
+            else:
+                bot.session_file = None
+
             return bot
         except Exception as _:
             raise Exception(f"Not Found Strategy : {args.strategy}")

--- a/src/factory.py
+++ b/src/factory.py
@@ -44,7 +44,7 @@ class BotFactory():
 
                     use_stored_session = query_yes_no("Session Found. Do you want to use it?", "no")
                     if use_stored_session:
-                        bot.session.load(vars)
+                        bot.set_session(vars)
                 except Exception as _:
                     logger.info("Session file is empty!")
             else:


### PR DESCRIPTION
You can specify to save the state of a strategy to a json file using --session switch followed by a filename.

`--session strategy.json
`

Inside your strategy, you need to declare your persisted state variables as self.session.xxxx inside the `__init__` menthod of the strategy class. Only inbuilt types are supported. Refer to types supported by JSON module for more info.

You can then read the session state from a session file while restarting bot. You will be prompted to accept the found session before proceeding.

Extreme caution is advised when using session persistence.